### PR TITLE
Count active player classes

### DIFF
--- a/Serverside/Server/game/src/cmd.cpp
+++ b/Serverside/Server/game/src/cmd.cpp
@@ -31,6 +31,7 @@ ACMD(do_notice);
 ACMD(do_map_notice);
 ACMD(do_big_notice);
 ACMD(do_who);
+ACMD(do_jobcount);
 ACMD(do_user);
 ACMD(do_disconnect);
 ACMD(do_kill);
@@ -212,6 +213,7 @@ struct command_info cmd_info[] =
 {
 	{ "!RESERVED!",	NULL,			0,			POS_DEAD,	GM_IMPLEMENTOR	},
 	{ "who",		do_who,			0,			POS_DEAD,	GM_HIGH_WIZARD	},
+	{ "jobcount",	do_jobcount,		0,			POS_DEAD,	GM_HIGH_WIZARD	},
 	{ "war",		do_war,			0,			POS_DEAD,	GM_PLAYER	},
 	{ "warp",		do_warp,		0,			POS_DEAD,	GM_HIGH_WIZARD	},
 	{ "user",		do_user,		0,			POS_DEAD,	GM_HIGH_WIZARD	},

--- a/Serverside/Server/game/src/cmd_gm.cpp
+++ b/Serverside/Server/game/src/cmd_gm.cpp
@@ -1139,6 +1139,40 @@ ACMD(do_who)
 			iTotal, paiEmpireUserCount[1], paiEmpireUserCount[2], paiEmpireUserCount[3], iLocal);
 }
 
+ACMD(do_jobcount)
+{
+	int countWarrior = 0;
+	int countAssassin = 0;
+	int countSura = 0;
+	int countShaman = 0;
+	int total = 0;
+
+	const DESC_MANAGER::DESC_SET & c_ref_set = DESC_MANAGER::instance().GetClientSet();
+	for (DESC_MANAGER::DESC_SET::const_iterator it = c_ref_set.begin(); it != c_ref_set.end(); ++it)
+	{
+		LPDESC d = *it;
+		if (!d)
+			continue;
+		LPCHARACTER tch = d->GetCharacter();
+		if (!tch)
+			continue;
+		if (!tch->IsPC())
+			continue;
+
+		++total;
+		switch (tch->GetJob())
+		{
+			case JOB_WARRIOR: ++countWarrior; break;
+			case JOB_ASSASSIN: ++countAssassin; break;
+			case JOB_SURA: ++countSura; break;
+			case JOB_SHAMAN: ++countShaman; break;
+			default: break;
+		}
+	}
+
+	ch->ChatPacket(CHAT_TYPE_INFO, "WARR:%d ASAS:%d SURA:%d SHAM:%d TOTAL:%d", countWarrior, countAssassin, countSura, countShaman, total);
+}
+
 class user_func
 {
 	public:


### PR DESCRIPTION
Add a `/jobcount` GM command to display the current online player count for each job class.

---
<a href="https://cursor.com/background-agent?bcId=bc-e31b0e45-f71b-448c-8c58-17bed9e94423">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e31b0e45-f71b-448c-8c58-17bed9e94423">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

