### PR TITLE
Add loot-theft mechanics (yang steal + ground-item steal) with cruelty penalty

### DIFF
--- a/LOOT_THEFT_SYSTEM_README.md
+++ b/LOOT_THEFT_SYSTEM_README.md
@@ -1,0 +1,50 @@
+# Loot Theft System (Yang + Ground Item Theft)
+
+Bu ekleme oyuna kısa bir **hırsızlık mekaniği** kazandırır:
+
+1. **Yang Çalma Efsunu**
+   - PvP sırasında proc olduğunda hedefin yang'ının %1-%8 arası çalınır.
+   - Başarılı çalmada hırsızın alignment değeri düşer (daha **zalim** olur).
+
+2. **Yerdeki Itemi Çalma**
+   - Item düşürüldükten sonra owner koruma süresi geçerse başka oyuncu itemi alabilir.
+   - Çalan oyuncu yine alignment cezası alır.
+
+## Dosyalar
+- `Serverside/loot_theft_system.h`
+- `Serverside/loot_theft_system.cpp`
+
+## Entegrasyon (kısa)
+
+### 1) Yang efsunu tetikleme örneği
+PvP hit çözümünde (örn. damage apply sonrası):
+
+```cpp
+// örnek değerler: %20 proc, kurbanın yang'ının %4'ü
+CLootTheftSystem::Instance().TryStealYang(attacker, victim, 20, 4);
+```
+
+### 2) Ground item alma noktasında kontrol
+Yerden item alma fonksiyonunda:
+
+```cpp
+CLootTheftSystem::ETheftResult res =
+    CLootTheftSystem::Instance().TryStealGroundItem(ch, item, itemOwnerPID, itemDropTime, 10);
+
+if (res == CLootTheftSystem::THEFT_RESULT_PROTECTED_ITEM)
+{
+    ch->ChatPacket(CHAT_TYPE_INFO, "Bu item hâlâ sahibi tarafından korunuyor.");
+    return;
+}
+```
+
+## Balans sabitleri
+Header içinde hızlı tuning için:
+- `THEFT_MIN_LEVEL`
+- `THEFT_MAX_YANG_PERCENT`
+- `THEFT_DEFAULT_ITEM_PROTECTION`
+- `THEFT_ALIGNMENT_PENALTY_YANG`
+- `THEFT_ALIGNMENT_PENALTY_ITEM`
+
+## Not
+Bu sistem PvP ekonomisini etkiler; canlıya almadan önce oran ve cezaları test shard'ında dengelemeniz önerilir.

--- a/Serverside/loot_theft_system.cpp
+++ b/Serverside/loot_theft_system.cpp
@@ -1,0 +1,119 @@
+#include "loot_theft_system.h"
+
+#include "char.h"
+#include "char_manager.h"
+#include "item.h"
+#include "item_manager.h"
+#include "log.h"
+#include "utils.h"
+
+CLootTheftSystem& CLootTheftSystem::Instance()
+{
+    static CLootTheftSystem s_theftSystem;
+    return s_theftSystem;
+}
+
+bool CLootTheftSystem::RollChance(BYTE bChance) const
+{
+    if (bChance == 0)
+        return false;
+
+    if (bChance >= 100)
+        return true;
+
+    return (number(1, 100) <= bChance);
+}
+
+bool CLootTheftSystem::IsValidPvPTheft(LPCHARACTER pkThief, LPCHARACTER pkVictim) const
+{
+    if (!pkThief || !pkVictim)
+        return false;
+
+    if (pkThief == pkVictim)
+        return false;
+
+    if (pkThief->GetLevel() < THEFT_MIN_LEVEL)
+        return false;
+
+    if (pkVictim->IsNPC() || pkVictim->IsDead())
+        return false;
+
+    return true;
+}
+
+CLootTheftSystem::ETheftResult CLootTheftSystem::TryStealYang(LPCHARACTER pkThief, LPCHARACTER pkVictim, BYTE bBaseChance, BYTE bStealPercent)
+{
+    if (!IsValidPvPTheft(pkThief, pkVictim))
+        return THEFT_RESULT_INVALID_TARGET;
+
+    if (!RollChance(bBaseChance))
+        return THEFT_RESULT_CHANCE_FAILED;
+
+    if (bStealPercent == 0)
+        bStealPercent = 1;
+
+    if (bStealPercent > THEFT_MAX_YANG_PERCENT)
+        bStealPercent = THEFT_MAX_YANG_PERCENT;
+
+    const long lVictimYang = pkVictim->GetGold();
+    if (lVictimYang <= 0)
+        return THEFT_RESULT_INSUFFICIENT_YANG;
+
+    long lStealAmount = (lVictimYang * bStealPercent) / 100;
+    if (lStealAmount <= 0)
+        lStealAmount = 1;
+
+    pkVictim->PointChange(POINT_GOLD, -lStealAmount, true);
+    pkThief->PointChange(POINT_GOLD, lStealAmount, true);
+
+    ApplyCrueltyPenalty(pkThief, THEFT_ALIGNMENT_PENALTY_YANG);
+
+    pkThief->ChatPacket(CHAT_TYPE_INFO, "Efsun aktif: %ld Yang çaldın. Zalimliğin arttı.", lStealAmount);
+    pkVictim->ChatPacket(CHAT_TYPE_INFO, "%s senden %ld Yang çaldı!", pkThief->GetName(), lStealAmount);
+
+    LogManager::instance().CharLog(pkThief, pkVictim->GetPlayerID(), "YANG_THEFT", "amount %ld", lStealAmount);
+    return THEFT_RESULT_OK;
+}
+
+CLootTheftSystem::ETheftResult CLootTheftSystem::TryStealGroundItem(LPCHARACTER pkThief, LPITEM pkItem, DWORD dwOwnerPID, time_t tDropTime, DWORD dwProtectionSec)
+{
+    if (!pkThief || !pkItem)
+        return THEFT_RESULT_NOT_ALLOWED;
+
+    if (pkThief->GetLevel() < THEFT_MIN_LEVEL)
+        return THEFT_RESULT_NOT_ALLOWED;
+
+    if (dwProtectionSec == 0)
+        dwProtectionSec = THEFT_DEFAULT_ITEM_PROTECTION;
+
+    const time_t tNow = time(0);
+    if (dwOwnerPID != 0 && pkThief->GetPlayerID() != dwOwnerPID)
+    {
+        if ((tNow - tDropTime) < static_cast<time_t>(dwProtectionSec))
+            return THEFT_RESULT_PROTECTED_ITEM;
+    }
+
+    if (!pkThief->CanHandleItem())
+        return THEFT_RESULT_NOT_ALLOWED;
+
+    if (!pkThief->AutoGiveItem(pkItem))
+        return THEFT_RESULT_NOT_ALLOWED;
+
+    ApplyCrueltyPenalty(pkThief, THEFT_ALIGNMENT_PENALTY_ITEM);
+
+    pkThief->ChatPacket(CHAT_TYPE_INFO, "Yerdeki itemi çaldın: %s. Zalimlik puanın arttı.", pkItem->GetName());
+    LogManager::instance().ItemLog(pkThief, pkItem, "GROUND_ITEM_THEFT", pkItem->GetName());
+
+    return THEFT_RESULT_OK;
+}
+
+void CLootTheftSystem::ApplyCrueltyPenalty(LPCHARACTER pkThief, long lPenaltyValue)
+{
+    if (!pkThief || lPenaltyValue <= 0)
+        return;
+
+    // Alignment düştükçe karakter daha zalim olur.
+    pkThief->PointChange(POINT_ALIGNMENT, -lPenaltyValue);
+
+    // İsteğe bağlı: sabit bir alt sınır koymak isteyenler burada kısıtlayabilir.
+}

--- a/Serverside/loot_theft_system.h
+++ b/Serverside/loot_theft_system.h
@@ -1,0 +1,51 @@
+#ifndef __HEADER_LOOT_THEFT_SYSTEM_H__
+#define __HEADER_LOOT_THEFT_SYSTEM_H__
+
+#include "char.h"
+#include "item.h"
+
+// Basit hırsızlık sistemi:
+// 1) PvP sırasında yang çalma efsunu
+// 2) Yere düşen itemi owner koruma süresi bitince çalma mekaniği
+// 3) Hırsız karakter her başarılı hırsızlıkta daha "zalim" olur (alignment düşer)
+
+class CLootTheftSystem
+{
+public:
+    enum ETheftResult
+    {
+        THEFT_RESULT_OK = 0,
+        THEFT_RESULT_INVALID_TARGET = 1,
+        THEFT_RESULT_INSUFFICIENT_YANG = 2,
+        THEFT_RESULT_PROTECTED_ITEM = 3,
+        THEFT_RESULT_CHANCE_FAILED = 4,
+        THEFT_RESULT_NOT_ALLOWED = 5,
+    };
+
+    static CLootTheftSystem& Instance();
+
+    // Yang çalma efsunu (ör: saldırıda proc)
+    ETheftResult TryStealYang(LPCHARACTER pkThief, LPCHARACTER pkVictim, BYTE bBaseChance, BYTE bStealPercent);
+
+    // Yere düşen item çalma mekaniği
+    ETheftResult TryStealGroundItem(LPCHARACTER pkThief, LPITEM pkItem, DWORD dwOwnerPID, time_t tDropTime, DWORD dwProtectionSec);
+
+    // Zalimlik cezası (alignment negatife gider)
+    void ApplyCrueltyPenalty(LPCHARACTER pkThief, long lPenaltyValue);
+
+private:
+    CLootTheftSystem() {}
+    ~CLootTheftSystem() {}
+
+    bool RollChance(BYTE bChance) const;
+    bool IsValidPvPTheft(LPCHARACTER pkThief, LPCHARACTER pkVictim) const;
+};
+
+// Önerilen balans sabitleri
+#define THEFT_MIN_LEVEL 35
+#define THEFT_MAX_YANG_PERCENT 8
+#define THEFT_DEFAULT_ITEM_PROTECTION 10
+#define THEFT_ALIGNMENT_PENALTY_YANG 800
+#define THEFT_ALIGNMENT_PENALTY_ITEM 1500
+
+#endif


### PR DESCRIPTION
### Motivation

- Add a simple theft subsystem to allow PvP yang stealing and stealing of ground-dropped items after owner-protection expires. 
- Penalize successful thieves by reducing their alignment so the thief becomes more "zalim" (cruel), enabling balance/roleplay consequences.

### Description

- Introduce `CLootTheftSystem` with `TryStealYang(...)`, `TryStealGroundItem(...)` and `ApplyCrueltyPenalty(...)` in `Serverside/loot_theft_system.h` and `Serverside/loot_theft_system.cpp` to handle validation, chance rolls, transfers, item pickup, logging and alignment penalties. 
- Add tuning constants for quick balancing: `THEFT_MIN_LEVEL`, `THEFT_MAX_YANG_PERCENT`, `THEFT_DEFAULT_ITEM_PROTECTION`, `THEFT_ALIGNMENT_PENALTY_YANG` and `THEFT_ALIGNMENT_PENALTY_ITEM`. 
- Provide a short integration guide and usage examples in `LOOT_THEFT_SYSTEM_README.md` showing where to call `TryStealYang` in PvP hit resolution and how to gate ground-item pickup. 
- All changes are server-side and designed as a reusable subsystem to integrate into combat and ground-item pickup handlers.

### Testing

- Verified new files are present with `git status --short` which listed the three new files as untracked before committing. 
- Committed the changes using `git add` + `git commit -m "Add loot theft mechanic for yang and dropped items"` which succeeded. 
- Printed and reviewed the added sources and README using `nl -ba Serverside/loot_theft_system.h`, `nl -ba Serverside/loot_theft_system.cpp` and `nl -ba LOOT_THEFT_SYSTEM_README.md`, confirming contents. 
- Confirmed the commit with `git log -1 --oneline` showing the new commit message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a703230f2c83328874e510230091b7)